### PR TITLE
Dev logging -> Beacon受信状態の条件分岐の改善

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,7 @@ on:
     branches: 
       - main
       - mtp
+      - dev-logging
 
 jobs:
   build-and-push:

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function handleEvent(event) {
       notifiedUserIDs[userID].push(hwid);
 
 
-    } else if (notifiedUserIDs[userID].indexOf(hwid) !== hwid && notifiedUserIDs.indexOf(userID) !== -1) {
+    } else if (notifiedUserIDs[userID].indexOf(hwid) !== -1 && notifiedUserIDs.indexOf(userID) !== -1) {
       // 既に通知済みのユーザーにはメッセージを送信
       console.log("2度目です。");
       client.replyMessage(event.replyToken, {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-//ログの機能作ります。
+//ログの機能じゃないです。hwidをユーザIDに紐づけて記録して1回目と2回目のBeacon受信をより正確にする
 
 import express from "express";
 import { Client, middleware } from "@line/bot-sdk";
@@ -96,6 +96,14 @@ function handleEvent(event) {
       client.replyMessage(event.replyToken, {
         type: "text",
         text: "2度目です。"+ hwid,
+      });
+    }
+    else
+    {
+      console.log("その他");
+      client.replyMessage(event.replyToken, {
+        type: "text",
+        text: "無効な検知です。"+ hwid,
       });
     }
   } else {

--- a/index.js
+++ b/index.js
@@ -73,6 +73,15 @@ function getHwid(userID) {
   return userHwidMap[userID] || [];
 }
 
+//タイムスタンプを比較して設定した時間以上経過しているかどうかをチェックする
+function isTimestampExpired(timestamp) {
+  const currentTime = Date.now(); // 現在の時刻を取得（ミリ秒単位）
+  const tenMinutesInMillis = 10 * 60 * 1000; // 10分をミリ秒単位に変換
+
+  return currentTime - timestamp > tenMinutesInMillis;
+}
+
+
 
 
 function handleEvent(event) {
@@ -88,6 +97,23 @@ function handleEvent(event) {
     console.log("beaconを検知しました");
     const hwid = event.beacon.hwid; //　ハードウェアIDを取得
     const userID = event.source.userId; // ユーザーIDを取得
+    const time = event.timestamp;//タイムスタンプを取得
+
+    //設定した時間以上経過している場合、初期化を行う。
+    if (isTimestampExpired(timestamp)) {
+      // timestampが10分以上経過している場合、初期化を行う
+      console.log("Timestampが10分以上経過しています。初期化を行います。");
+
+      // ここで特定のユーザーに関連する情報を初期化するコードを追加する
+      countMap[userID] = 0; // カウントを初期化
+      userHwidMap[userID] = []; // "hwid" 関連の情報を初期化
+
+      // ユーザーIDを通知済みリストから削除
+      const index = notifiedUserIDs.indexOf(userID);
+      if (index !== -1) {
+        notifiedUserIDs.splice(index, 1);
+      }
+    }
 
     if (hwid === "017190a280" && notifiedUserIDs.indexOf(userID) === -1) {
       // 特定の "hwid" かつ未通知のユーザーに対する条件分岐

--- a/index.js
+++ b/index.js
@@ -89,11 +89,6 @@ function handleEvent(event) {
     const hwid = event.beacon.hwid; //　ハードウェアIDを取得
     const userID = event.source.userId; // ユーザーIDを取得
 
-      // ユーザーごとに "hwid" を格納するオブジェクトを初期化
-    if (!notifiedUserIDs[userID]) {
-      notifiedUserIDs[userID] = [];
-    }
-
     if (hwid === "017190a280" && notifiedUserIDs.indexOf(userID) === -1) {
       // 特定の "hwid" かつ未通知のユーザーに対する条件分岐
       console.log("ビーコン017190a280を検知");

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function recordHwid(ID, hwID) {
 }
 // ユーザーごとに "hwid" を取得する関数
 function getHwid(ID) {
-  return userHwidMap[userID] || [];
+  return userHwidMap[ID] || [];
 }
 
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const app = express();
 // Middleware for signature verification
 app.use(middleware(config));
 
-// ユーザーIDを格納する配列です
+// ユーザーIDを格納する配列
 const notifiedUserIDs = [];
 
 app.post("/", (req, res) => {
@@ -82,7 +82,7 @@ function handleEvent(event) {
       console.log("ビーコン0171c239b0を検知");
       client.replyMessage(event.replyToken, {
         type: "text",
-        text: "ビーコン0171c239b0を検知しました",
+        text: "ビーコン0171c239b0を検知",
       });
       // ユーザーIDを通知済みリストに追加
       notifiedUserIDs.push(userID);
@@ -90,7 +90,7 @@ function handleEvent(event) {
       notifiedUserIDs[userID].push(hwid);
 
 
-    } else if (notifiedUserIDs[userID].indexOf(userID) !== hwid && notifiedUserIDs.indexOf(userID) !== -1) {
+    } else if (notifiedUserIDs[userID].indexOf(hwid) !== hwid && notifiedUserIDs.indexOf(userID) !== -1) {
       // 既に通知済みのユーザーにはメッセージを送信
       console.log("2度目です。");
       client.replyMessage(event.replyToken, {

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ function handleEvent(event) {
         type: "text",
         text: "2度目です。"+ hwid,
       });
-    } else if (notifiedUserIDs.indexOf(userID) !== -1 && getHwid(userID) === hwid) {
+    } else if (notifiedUserIDs.indexOf(userID) !== -1 && getHwid(userID) !== hwid) {
       console.log("既に受信済み");
       client.replyMessage(event.replyToken, {
         type: "text",

--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ function handleEvent(event) {
       recordHwid(userID, hwid);
 
 
-    } else if (notifiedUserIDs.indexOf(userID) !== -1 && getHwid(userID) === hwid && getCount(userID) === 2) {
+    } else if (notifiedUserIDs.indexOf(userID) !== -1 && getHwid(userID) === hwid && getCount(userID) === 1) {
       // 既に通知済みのユーザーにはメッセージを送信
       console.log("2度目です。");
       //2回目の受信であることを記録

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ app.listen(PORT);
 // IDに紐づけてカウントを増やすハンドラ
 function incrementCount(ID) {
   if (!countMap[ID]) {
-      countMap[ID] = 0;
+      countMap[ID] = 1;
   } else {
       countMap[ID]++;
   }
@@ -117,7 +117,7 @@ function handleEvent(event) {
       recordHwid(userID, hwid);
 
 
-    } else if (notifiedUserIDs.indexOf(userID) !== -1 && getHwid(userID) !== hwid && getCount(userID) === 1) {
+    } else if (notifiedUserIDs.indexOf(userID) !== -1 && getHwid(userID) !== hwid && getCount(userID) === 3) {
       // 既に通知済みのユーザーにはメッセージを送信
       console.log("2度目です。");
       //2回目の受信であることを記録

--- a/index.js
+++ b/index.js
@@ -100,6 +100,7 @@ function handleEvent(event) {
       notifiedUserIDs.push(userID);
       // ユーザーごとに受信回数を記録
       incrementCount(userID);
+      console.log(getCount(userID));
       recordHwid(userID, hwid);
 
 
@@ -114,6 +115,7 @@ function handleEvent(event) {
       notifiedUserIDs.push(userID);
       // ユーザーごとに受信回数を記録
       incrementCount(userID);
+      console.log(getCount(userID));
       recordHwid(userID, hwid);
 
 
@@ -122,6 +124,7 @@ function handleEvent(event) {
       console.log("2度目です。");
       //2回目の受信であることを記録
       incrementCount(userID)
+      console.log(getCount(userID));
       client.replyMessage(event.replyToken, {
         type: "text",
         text: "2度目です。"+ hwid,

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ app.listen(PORT);
 // IDに紐づけてカウントを増やすハンドラ
 function incrementCount(ID) {
   if (!countMap[ID]) {
-      countMap[ID] = 1;
+      countMap[ID] = 0;
   } else {
       countMap[ID]++;
   }
@@ -70,7 +70,7 @@ function recordHwid(ID, hwID) {
 }
 // ユーザーごとに "hwid" を取得する関数
 function getHwid(ID) {
-  return userHwidMap[ID] || [];
+  return userHwidMap[userID] || [];
 }
 
 
@@ -131,7 +131,7 @@ function handleEvent(event) {
         type: "text",
         text: "2度目です。"+ hwid,
       });
-    } else if (getHwid(userID) === hwid) {
+    } else if (notifiedUserIDs.indexOf(userID) !== -1 && getHwid(userID) === hwid) {
       console.log("既に受信済み");
       client.replyMessage(event.replyToken, {
         type: "text",

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+//ログの機能作ります。
+
 import express from "express";
 import { Client, middleware } from "@line/bot-sdk";
 import crypto from "crypto";

--- a/index.js
+++ b/index.js
@@ -117,11 +117,11 @@ function handleEvent(event) {
       recordHwid(userID, hwid);
 
 
-    } else if (notifiedUserIDs.indexOf(userID) !== -1 && getHwid(userID) !== hwid && getCount(userID) === 3) {
+    } else if (notifiedUserIDs.indexOf(userID) !== -1 && getHwid(userID) === hwid && getCount(userID) === 2) {
       // 既に通知済みのユーザーにはメッセージを送信
       console.log("2度目です。");
       //2回目の受信であることを記録
-      incrementCount(userID);
+      incrementCount(userID)
       client.replyMessage(event.replyToken, {
         type: "text",
         text: "2度目です。"+ hwid,

--- a/index.js
+++ b/index.js
@@ -52,20 +52,31 @@ function handleEvent(event) {
       type: "text",
       text: event.message.text,
     });
+
+  //Beaconを受信したとき
   } else if (event.type === "beacon") {
     console.log("beaconを検知しました");
-    const hwid = event.beacon.hwid;
+    const hwid = event.beacon.hwid; //　ハードウェアIDを取得
     const userID = event.source.userId; // ユーザーIDを取得
+
+      // ユーザーごとに "hwid" を格納するオブジェクトを初期化
+    if (!notifiedUserIDs[userID]) {
+      notifiedUserIDs[userID] = [];
+    }
 
     if (hwid === "017190a280" && notifiedUserIDs.indexOf(userID) === -1) {
       // 特定の "hwid" かつ未通知のユーザーに対する条件分岐
       console.log("ビーコン017190a280を検知");
       client.replyMessage(event.replyToken, {
         type: "text",
-        text: "ビーコンを017190a280を検知しました",
+        text: "ビーコン017190a280を検知",
       });
       // ユーザーIDを通知済みリストに追加
       notifiedUserIDs.push(userID);
+      // ユーザーごとに "hwid" を記録
+      notifiedUserIDs[userID].push(hwid);
+
+
     } else if (hwid === "0171c239b0" && notifiedUserIDs.indexOf(userID) === -1) {
       // 他の "hwid" かつ未通知のユーザーに対する条件分岐
       console.log("ビーコン0171c239b0を検知");
@@ -75,7 +86,11 @@ function handleEvent(event) {
       });
       // ユーザーIDを通知済みリストに追加
       notifiedUserIDs.push(userID);
-    } else if (notifiedUserIDs.indexOf(userID) !== -1) {
+      // ユーザーごとに "hwid" を記録
+      notifiedUserIDs[userID].push(hwid);
+
+
+    } else if (notifiedUserIDs[userID].indexOf(userID) !== hwid && notifiedUserIDs.indexOf(userID) !== -1) {
       // 既に通知済みのユーザーにはメッセージを送信
       console.log("2度目です。");
       client.replyMessage(event.replyToken, {

--- a/index.js
+++ b/index.js
@@ -48,29 +48,29 @@ app.post("/", (req, res) => {
 app.listen(PORT);
 
 // IDに紐づけてカウントを増やすハンドラ
-function incrementCount(ID) {
-  if (!countMap[ID]) {
-      countMap[ID] = 1;
+function incrementCount(userID) {
+  if (!countMap[userID]) {
+      countMap[userID] = 1;
   } else {
-      countMap[ID]++;
+      countMap[userID]++;
   }
 }
 // IDに紐づけたカウントを取得するハンドラ
-function getCount(ID) {
-  return countMap[ID] || 0;
+function getCount(userID) {
+  return countMap[userID] || 0;
 }
 
 
 // ユーザーごとに "hwid" を記録する関数
-function recordHwid(ID, hwID) {
-  if (!userHwidMap[ID]) {
-      userHwidMap[ID] = [];
+function recordHwid(userID, hwid) {
+  if (!userHwidMap[userID]) {
+      userHwidMap[userID] = [];
   }
-  userHwidMap[ID].push(hwID);
+  userHwidMap[userID].push(hwid);
 }
 // ユーザーごとに "hwid" を取得する関数
-function getHwid(ID) {
-  return userHwidMap[ID] || [];
+function getHwid(userID) {
+  return userHwidMap[userID] || [];
 }
 
 
@@ -119,7 +119,7 @@ function handleEvent(event) {
       recordHwid(userID, hwid);
 
 
-    } else if (notifiedUserIDs.indexOf(userID) !== -1 && getHwid(userID) === hwid && getCount(userID) === 1) {
+    } else if (notifiedUserIDs.indexOf(userID) !== -1 && getHwid(userID) != hwid && getCount(userID) == 1) {
       // 既に通知済みのユーザーにはメッセージを送信
       console.log("2度目です。");
       //2回目の受信であることを記録
@@ -129,7 +129,7 @@ function handleEvent(event) {
         type: "text",
         text: "2度目です。"+ hwid,
       });
-    } else if (notifiedUserIDs.indexOf(userID) !== -1 && getHwid(userID) !== hwid) {
+    } else if (notifiedUserIDs.indexOf(userID) !== -1 && getHwid(userID) == hwid) {
       console.log("既に受信済み");
       client.replyMessage(event.replyToken, {
         type: "text",


### PR DESCRIPTION
タイトルと内容が異なる。
・Beacon受信受理条件のより厳密な条件分岐
・一定時間（10分）以上経過後に受信した場合、サーバの配列に保存されているユーザ情報を初期化、再登録し直し、再度Beaconの受信を受理する機能の追加